### PR TITLE
Define the undefined name 'runtime'

### DIFF
--- a/SparseSC/optimizers/cd_line_search.py
+++ b/SparseSC/optimizers/cd_line_search.py
@@ -4,6 +4,11 @@ from scipy.optimize import line_search
 import locale 
 locale.setlocale(locale.LC_ALL, '')
 
+try:
+    runtime
+except NameError:
+    runtime = RuntimeError
+
 class cd_res(object):
     def __init__(self, x, fun):
         self.x = x


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/microsoft/SparseSC on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./example-code.py:257:26: F821 undefined name 'best_L1_penalty_loo'
                LAMBDA = best_L1_penalty_loo,
                         ^
./example-code.py:325:62: F821 undefined name 'results'
        NEW_best_L1_penalty_ct = best_L1_penalty_ct * np.exp(results.x[0])
                                                             ^
./example-code.py:326:52: F821 undefined name 'results'
        best_L2_penalty = L2_pen_start_ct * np.exp(results.x[1])
                                                   ^
./examples/fit_poc.py:43:29: E999 SyntaxError: invalid syntax
            grid_points = 20L,
                            ^
./SparseSC/optimizers/cd_line_search.py:37:15: F821 undefined name 'runtime'
        raise runtime("Failed to take a step")
              ^
./SparseSC/optimizers/cd_line_search.py:52:19: F821 undefined name 'runtime'
            raise runtime("Failed to take a step")
                  ^
./SparseSC/utils/sub_matrix_inverse.py:38:50: F821 undefined name 'xi_k'
                                   (eps, k,  abs(xi_k - x[k_rng2].I).max(), ) )
                                                 ^
./SparseSC/utils/sub_matrix_inverse.py:59:151: F821 undefined name 'xi_k'
            raise RuntimeError("Fast and brute force methods were not within epsilon (%s) for sub-matrix k = %s; max difference = %s" % (eps, k,  abs(xi_k - x[k_rng2].I).max(), ) )
                                                                                                                                                      ^
./SparseSC/utils/sub_matrix_inverse.py:102:18: F821 undefined name 'subinv'
            zz = subinv(x,10e-10)
                 ^
./SparseSC/utils/sub_matrix_inverse.py:156:14: F821 undefined name 'subinv'
        zz = subinv(x,10e-10)
             ^
./SparseSC/utils/sub_matrix_inverse.py:164:14: F821 undefined name 'subinv'
        zz = subinv(x)
             ^
1     E999 SyntaxError: invalid syntax
10    F821 undefined name 'runtime'
11
```

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree