### PR TITLE
Adjust for cases where max_n_pl < n_pl for p2min

### DIFF
--- a/src/SparseSC/utils/metrics_utils.py
+++ b/src/SparseSC/utils/metrics_utils.py
@@ -290,7 +290,7 @@ def _gen_placebo_stats_from_diffs(
         # math a bit nicer, I will reject a hypothesis if pval<=(1-level)
         assert 0 < level < 1 and level > 0, "Use a level in [0,1]"
         alpha = 1 - level
-        p2min = 2 / n_pl
+        p2min = 2 / min(n_pl, max_n_pl)
         alpha_ind = max((1, round(alpha / p2min))) - 1
         alpha = alpha_ind * p2min
 


### PR DESCRIPTION
Adjusting for cases when many controls and many treatments are available.

One line change: `p2min = 2 / min(n_pl, max_n_pl)` where `max_n_pl = 1000000` as default. Since this function is not callable by `estimate_effects`, making the change here.