### PR TITLE
Fix TypeError at cross-fitting step in verbose=2 logging

### DIFF
--- a/src/SparseSC/utils/print_progress.py
+++ b/src/SparseSC/utils/print_progress.py
@@ -52,9 +52,9 @@ def print_progress(iteration, total=100, prefix='', suffix='', decimals=1, bar_l
 def it_progressmsg(it, prefix="Loop", file=sys.stdout, count=None):
     for i, item in enumerate(it):
         if count is None:
-            file.write(prefix + ": " + i + "\n")
+            file.write(f"{prefix}: {i}\n")
         else:
-            file.write(prefix + ": " + i + " of " + count + "\n")
+            file.write(f"{prefix}: {i} of {count}\n")
         file.flush()
         yield item
     file.write(prefix + ": FINISHED\n")


### PR DESCRIPTION
When calling `estimate_effects` with `Fast=True` and `verbose=2`, when the cross-fitting step is reached, I get an error from the logging util function `it_progressmsg`:
`TypeError: can only concatenate str (not "int") to str`
(I didn't test extensively to see if the same occurs in other conditions, e.g. slow fit.)

This is a simple change to use an f-string instead so that an integer (or anything printable) can be accepted.